### PR TITLE
feat: allow function for specifying field type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ type DerivedFieldDefinition = {
   identifiers: Array<Identifier>,
   inflect: function,
   resolve: function,
+  type?: function,
   description?: string
-  returnTypeName?: string
 }
 ```
 The Scenarios section below provides guidance on structuring `identifiers`, `inflect`, and `resolve` for your specific use case.
 
-Use `description` to populate the field description in the schema.
+Use `type` to specify the GraphQL type that the `resolve` function returns. Default: String
 
-Use `returnTypeName` to specify the name of the GraphQL type that `resolve` function returns.  Default: "String"
+Use `description` to populate the field description in the schema.
 
 ## Scenarios
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ app.listen(5000);
 Provide `derivedFieldDefinitions` as an array of objects with the following structure:
 
 ```
-type DerivedFieldDefinition = {
+{
   identifiers: Array<Identifier>,
   inflect: function,
   resolve: function,
-  type?: function,
+  type?: string | build => T,
   description?: string
 }
 ```
 The Scenarios section below provides guidance on structuring `identifiers`, `inflect`, and `resolve` for your specific use case.
 
-Use `type` to specify the GraphQL type that the `resolve` function returns. Default: String
+Use `type` to specify the GraphQL type that the `resolve` function returns. This can be a string identifying the GraphQL type name, or a function (with the `build` helper available as the first argument) that returns a GraphQL type. Default: String
 
 Use `description` to populate the field description in the schema.
 

--- a/__tests__/fixtures/queries/derived-field.graphql
+++ b/__tests__/fixtures/queries/derived-field.graphql
@@ -7,5 +7,6 @@ query {
   twoColumn_derivedField_sourceField1_sourceField2: allPeople { nodes { combinedNameAndEmail, name, email } }
   twoColumn_sourceField1_sourceField2: allPeople { nodes { name, email } }
   withReturnTypeBoolean: allPeople { nodes { hasName } }
+  withReturnTypeComposite: allPeople { nodes { name, menuExtrasWithDefaults { menuExtra, isEnabled } } }
   withTaggedColumn: allPeople { nodes { name, email, avatarUrl } }
 }

--- a/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -93,6 +93,18 @@ Object {
         },
       ],
     },
+    "withReturnTypeComposite": Object {
+      "nodes": Array [
+        Object {
+          "menuExtrasWithDefaults": Array [],
+          "name": "John Smith",
+        },
+        Object {
+          "menuExtrasWithDefaults": Array [],
+          "name": "Sara Smith",
+        },
+      ],
+    },
     "withTaggedColumn": Object {
       "nodes": Array [
         Object {

--- a/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -87,6 +87,19 @@ type DeletePersonPayload {
   query: Query
 }
 
+enum MenuExtrasType {
+  EMAILS
+  LOCATIONS
+  LOGO
+  PHONES
+  SEARCH
+}
+
+type MenuExtrasWithDefault {
+  isEnabled: Boolean
+  menuExtra: MenuExtrasType
+}
+
 \\"\\"\\"
 The root mutation type which contains root level fields which mutate data.
 \\"\\"\\"
@@ -189,6 +202,8 @@ enum PeopleOrderBy {
   EMAIL_DESC
   ID_ASC
   ID_DESC
+  MENU_EXTRAS_ASC
+  MENU_EXTRAS_DESC
   NAME_ASC
   NAME_DESC
   NATURAL
@@ -207,6 +222,8 @@ type Person implements Node {
   email: String!
   hasName: Boolean
   id: Int!
+  menuExtras: [MenuExtrasType]
+  menuExtrasWithDefaults: [MenuExtrasWithDefault]
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
@@ -233,6 +250,9 @@ input PersonCondition {
   \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
   id: Int
 
+  \\"\\"\\"Checks for equality with the object’s \`menuExtras\` field.\\"\\"\\"
+  menuExtras: [MenuExtrasType]
+
   \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
   name: String
 }
@@ -244,6 +264,7 @@ input PersonInput {
   \\"\\"\\"The person’s email\\"\\"\\"
   email: String!
   id: Int
+  menuExtras: [MenuExtrasType]
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
@@ -258,6 +279,7 @@ input PersonPatch {
   \\"\\"\\"The person’s email\\"\\"\\"
   email: String
   id: Int
+  menuExtras: [MenuExtrasType]
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String
@@ -465,6 +487,14 @@ type DeletePersonPayload {
   query: Query
 }
 
+enum MenuExtrasType {
+  EMAILS
+  LOCATIONS
+  LOGO
+  PHONES
+  SEARCH
+}
+
 \\"\\"\\"
 The root mutation type which contains root level fields which mutate data.
 \\"\\"\\"
@@ -567,6 +597,8 @@ enum PeopleOrderBy {
   EMAIL_DESC
   ID_ASC
   ID_DESC
+  MENU_EXTRAS_ASC
+  MENU_EXTRAS_DESC
   NAME_ASC
   NAME_DESC
   NATURAL
@@ -580,6 +612,7 @@ type Person implements Node {
   \\"\\"\\"The person’s email\\"\\"\\"
   email: String!
   id: Int!
+  menuExtras: [MenuExtrasType]
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
@@ -603,6 +636,9 @@ input PersonCondition {
   \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
   id: Int
 
+  \\"\\"\\"Checks for equality with the object’s \`menuExtras\` field.\\"\\"\\"
+  menuExtras: [MenuExtrasType]
+
   \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
   name: String
 }
@@ -614,6 +650,7 @@ input PersonInput {
   \\"\\"\\"The person’s email\\"\\"\\"
   email: String!
   id: Int
+  menuExtras: [MenuExtrasType]
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
@@ -628,6 +665,7 @@ input PersonPatch {
   \\"\\"\\"The person’s email\\"\\"\\"
   email: String
   id: Int
+  menuExtras: [MenuExtrasType]
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String

--- a/__tests__/integration/derivedFieldDefinitions.js
+++ b/__tests__/integration/derivedFieldDefinitions.js
@@ -34,4 +34,27 @@ module.exports = [
     inflect: fieldName => fieldName.replace("Key", "Url"),
     resolve: key => `https://example.com/${key}`,
   },
+  {
+    identifiers: [
+      {
+        table: "p.person",
+        columns: ["menu_extras"],
+      },
+    ],
+    type: build => {
+      const {
+        getTypeByName,
+        graphql: { GraphQLList },
+      } = build;
+      const compositeTypeName = "MenuExtrasWithDefault";
+      const compositeType = getTypeByName(compositeTypeName);
+      if (!compositeType)
+        throw new Error(`Could not find composite type '${compositeTypeName}'`);
+      return new GraphQLList(compositeType);
+    },
+    inflect: fieldName => `${fieldName}WithDefaults`,
+    resolve: () => {
+      return [];
+    },
+  },
 ];

--- a/__tests__/plugin-test-schema.sql
+++ b/__tests__/plugin-test-schema.sql
@@ -2,11 +2,25 @@ drop schema if exists p cascade;
 
 create schema p;
 
+create type p.menu_extras_type as enum (
+  'logo',
+  'emails',
+  'locations',
+  'phones',
+  'search'
+);
+
+create type p.menu_extras_with_defaults as (
+  menu_extra p.menu_extras_type,
+  is_enabled boolean
+);
+
 create table p.person (
   id serial primary key,
   name text not null,
   email text not null,
-  avatar_key text
+  avatar_key text,
+  menu_extras p.menu_extras_type[]
 );
 
 comment on column p.person.name is 'The person’s name';

--- a/src/DerivedFieldPlugin.js
+++ b/src/DerivedFieldPlugin.js
@@ -80,11 +80,14 @@ function DerivedFieldPlugin(builder, { derivedFieldDefinitions }) {
                 Boolean: GraphQLBoolean,
               };
               return {
-                type: def.returnTypeName
-                  ? getTypeByName(def.returnTypeName) ||
-                    scalarTypes[def.returnTypeName] ||
-                    GraphQLString
-                  : GraphQLString,
+                type:
+                  typeof def.type === "function"
+                    ? def.type(build)
+                    : def.returnTypeName
+                    ? getTypeByName(def.returnTypeName) ||
+                      scalarTypes[def.returnTypeName] ||
+                      GraphQLString
+                    : GraphQLString,
                 description: def.description,
                 resolve: data => {
                   if (

--- a/src/DerivedFieldPlugin.js
+++ b/src/DerivedFieldPlugin.js
@@ -79,15 +79,34 @@ function DerivedFieldPlugin(builder, { derivedFieldDefinitions }) {
                 Float: GraphQLFloat,
                 Boolean: GraphQLBoolean,
               };
+              let type;
+              if (typeof def.type === "string") {
+                type = getTypeByName(def.type) || scalarTypes[def.type];
+                if (!type) {
+                  throw new Error(
+                    "Derived field definition requires 'type' string to be a valid GraphQL type name"
+                  );
+                }
+              } else if (typeof def.type === "function") {
+                type = def.type(build);
+                if (!type) {
+                  throw new Error(
+                    "Derived field definition requires 'type' function to return a valid GraphQL type"
+                  );
+                }
+              } else if (def.returnTypeName) {
+                // DEPRECATED
+                type =
+                  getTypeByName(def.returnTypeName) ||
+                  scalarTypes[def.returnTypeName];
+                if (!type) {
+                  throw new Error(
+                    "Derived field definition requires 'returnTypeName' string to be a valid GraphQL type name"
+                  );
+                }
+              }
               return {
-                type:
-                  typeof def.type === "function"
-                    ? def.type(build)
-                    : def.returnTypeName
-                    ? getTypeByName(def.returnTypeName) ||
-                      scalarTypes[def.returnTypeName] ||
-                      GraphQLString
-                    : GraphQLString,
+                type: type || GraphQLString,
                 description: def.description,
                 resolve: data => {
                   if (


### PR DESCRIPTION
This introduces a new `type` property on derived field definitions, which must be either a string with a GraphQL type name or a function that returns a GraphQL type. If using a function, the `build` object is passed as the first argument.